### PR TITLE
Home Page Grid CSS rows of 3

### DIFF
--- a/main_app/static/css/home.css
+++ b/main_app/static/css/home.css
@@ -126,3 +126,22 @@ form.login p {
 .favorite-button:hover {
     background-color: var(--muted-sage);
 }
+
+.resort-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1.5rem;
+    padding: 0 1rem;
+ }
+
+ @media (max-width: 768px) {
+    .resort-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+@media (max-width: 480px) {
+    .resort-grid {
+        grid-template-columns: 1fr;
+    }
+}

--- a/main_app/static/css/resorts/resorts_page.css
+++ b/main_app/static/css/resorts/resorts_page.css
@@ -1,9 +1,9 @@
 .resort-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-    gap: 2rem;
-    margin-top: 2rem;
-}
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1.5rem;
+    padding: 0 1rem;
+  }
 
 .resort-card {
     background-color: rgba(255, 255, 255, 0.15);
@@ -40,4 +40,24 @@
 
 .favorite-button:hover {
     background-color: var(--muted-sage);
+}
+
+/* resort-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 2fr);
+    gap: 1.5rem;
+    padding: 0 1rem;
+ } */
+
+
+ @media (max-width: 768px) {
+    .resort-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+@media (max-width: 480px) {
+    .resort-grid {
+        grid-template-columns: 1fr;
+    }
 }


### PR DESCRIPTION
This pull request includes changes to the CSS files to improve the layout and responsiveness of the resort grid on the home and resorts pages. The most important changes include adding a new `.resort-grid` class in `home.css`, modifying the `.resort-grid` class in `resorts_page.css`, and adding media queries for responsive design.

### Improvements to layout and responsiveness:

* [`main_app/static/css/home.css`](diffhunk://#diff-dd269bc4f9a8c524356844c9d58b29f00f3470de019f39d944658f7e58ba381cR129-R147): Added a new `.resort-grid` class with grid layout properties and media queries for different screen sizes.
* [`main_app/static/css/resorts/resorts_page.css`](diffhunk://#diff-db0472744bcf0f7e73f6f80a1af8dda7c75dc67a68a0e301cfe301fd16612df4L3-R5): Modified the `.resort-grid` class to use `auto-fit` instead of `auto-fill` for better responsiveness and adjusted the gap and padding.
* [`main_app/static/css/resorts/resorts_page.css`](diffhunk://#diff-db0472744bcf0f7e73f6f80a1af8dda7c75dc67a68a0e301cfe301fd16612df4R44-R63): Added media queries to the `.resort-grid` class for different screen sizes and commented out the previous grid layout code.