### PR TITLE
add css to resort fav page

### DIFF
--- a/main_app/static/css/resorts/favorite_resorts.css
+++ b/main_app/static/css/resorts/favorite_resorts.css
@@ -1,0 +1,55 @@
+.resort-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1.5rem;
+    padding: 0 1rem;
+  }
+
+.resort-card {
+    background-color: rgba(255, 255, 255, 0.15);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    border-radius: 8px;
+    text-align: center;
+    padding: 1rem;
+    position: relative;
+}
+
+.resort-card img {
+    width: 100% !important;
+   height: 200px !important;
+    object-fit: cover !important;
+    border-radius: 8px;
+}
+
+.resort-card h2 {
+    margin: 0.75rem 0;
+    color: #fff;
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+}
+
+.favorite-button {
+    background-color: var(--deep-teal);
+    color: var(--pure-white);
+    border: none;
+    padding: 0.5rem 1rem;
+    border-radius: 20px;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+}
+
+.favorite-button:hover {
+    background-color: var(--muted-sage);
+}
+
+@media (max-width: 768px) {
+    .resort-grid {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
+  
+  @media (max-width: 480px) {
+    .resort-grid {
+      grid-template-columns: 1fr;
+    }
+  }

--- a/main_app/templates/favorite_resorts.html
+++ b/main_app/templates/favorite_resorts.html
@@ -1,4 +1,8 @@
-{% extends 'base.html' %} {% load static %} {% block content %}
+{% extends 'base.html' %} {% load static %} 
+{% block head %}
+<link rel="stylesheet" href="{% static 'css/resorts/favorite_resorts.css' %}" />
+{% endblock %}
+{% block content %}
 <h1>Favorite Resorts Page</h1>
 <hr />
 <p class="page-content">This is the Favorite Resorts page</p>


### PR DESCRIPTION
This pull request includes changes to enhance the styling and structure of the Favorite Resorts page. The most important changes include the addition of a new CSS file for styling the resort cards and updates to the HTML template to incorporate the new styles.

Styling improvements:

* [`main_app/static/css/resorts/favorite_resorts.css`](diffhunk://#diff-5cdb2fb02453813eef8fccf50eb19bd8cd68eaacd7e25e4a92411bb4944ac889R1-R55): Added new styles for the `.resort-grid`, `.resort-card`, and `.favorite-button` classes to improve the layout and appearance of the resort cards. This includes grid layout, card styling, and responsive design for different screen sizes.

HTML template updates:

* [`main_app/templates/favorite_resorts.html`](diffhunk://#diff-11e1d870bbb3c5e9adcfe5d6c942caca835b581ca3cce8fe53681a195da3aea7L1-R5): Updated the HTML template to include the new CSS file for the Favorite Resorts page. This ensures that the new styles are applied to the page.