### PR TITLE
Remove text decoration from reservations

### DIFF
--- a/main_app/static/css/resorts/reservations.css
+++ b/main_app/static/css/resorts/reservations.css
@@ -49,6 +49,11 @@
     justify-content: center;
   }
 
+  .reservation-link {
+    text-decoration: none!important;
+    color: inherit!important;
+  }
+
   .edit-button {
     background-color: var(--deep-teal);
     color: var(--pure-white);


### PR DESCRIPTION
This pull request includes a small change to the `main_app/static/css/resorts/reservations.css` file. The change adds a new CSS class to style reservation links.

* [`main_app/static/css/resorts/reservations.css`](diffhunk://#diff-888a608179ddb2e26cde675e7a627ebabed75d7ea02e0c3c8da343ab0347252eR52-R56): Added a `.reservation-link` class to ensure text decoration is removed and color is inherited.